### PR TITLE
Verify Email

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -18,5 +18,6 @@ module.exports = function send (event, callback) {
     name: event.name || "", // allow email to be sent without name
     pixel_url: "https://" + process.env.EMAIL_APP_URL + "/read/" + token
   };
-  return sendemail(template, options, callback);
+  const merged = {...event, ...options}; // expose all of event to template
+  return sendemail(template, merged, callback);
 };

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -1,0 +1,23 @@
+<p>Hi!</p>
+
+<p>Thank you for signing up with your
+	email address: <strong>{{email}}</strong>!</p>
+
+<p>Please click the link to verify your address:
+	<a href="{{link}}">{{link}}</a>
+<br />
+Or if you prefer, copy-paste it into your web browser.
+</p>
+
+
+<p>If you have any questions or find any issues, big or small,
+	please drop us a note (by email or twitter) or
+	<a href="https://github.com/dwyl/app/labels/MVP">
+		add an issue to github</a>,
+	we <i>really appreciate</i> your feedback!</p>
+
+<p>Happy dwyling!</p>
+<p>Inês &amp; Nelson<p>
+<p><em>Co-Founders<em><p>
+<a href="http://www.dwyl.com">http://www.dwyl.com</a>
+<img src="{{pixel_url}}"/>

--- a/templates/verify.html
+++ b/templates/verify.html
@@ -1,7 +1,7 @@
 <p>Hi!</p>
 
 <p>Thank you for signing up with your
-	email address: <strong>{{email}}</strong>!</p>
+	email address: <strong>{{email}}</strong></p>
 
 <p>Please click the link to verify your address:
 	<a href="{{link}}">{{link}}</a>

--- a/templates/verify.txt
+++ b/templates/verify.txt
@@ -1,0 +1,16 @@
+Hi!
+
+Thank you for signing up to alpha test dwyl with your
+email address: {{email}}!
+
+Please follow this link to verify your address:
+{{link}}.
+
+If you have any questions or find any issues, big or small,
+please drop us a note or add an issue to GitHub:
+https://github.com/dwyl/app/labels/MVP
+We really appreciate your feedback!
+
+Inês & Nelson
+Co-Founders
+http://www.dwyl.com

--- a/test/send.test.js
+++ b/test/send.test.js
@@ -51,3 +51,22 @@ test('simulate bounce and complaint', function (t) {
     t.end();
   })
 });
+
+test('simulate verification email', function (t) {
+  const event = {
+    "email": [
+      "success@simulator.amazonses.com",
+      // "nelson@dwyl.com"
+    ],
+    "template": "verify",
+    "name": "Testy McTestface",
+    "id": 1,
+    "key": "simulate_verify",
+    "link": "https://dwyl.com/person/verify/StTqXEQ2l-Y"
+  }; // no template
+  send(event, function(err, data) {
+    console.log(data);
+    t.equal(data.MessageId.length, 60, "Sent! message_id: " + data.MessageId);
+    t.end();
+  })
+});


### PR DESCRIPTION
This PR adds the template for verifying an email address for https://github.com/dwyl/auth/issues/62
The `{{link}}` prop allows us to send the verification link from any App (_e.g. the Auth app_)

Example of verification email:
![image](https://user-images.githubusercontent.com/194400/80893739-f59ac780-8ccc-11ea-8a74-8005a4e9fea6.png)

Works as expected. 👍 
Now we just need to invoke it from the Auth App once someone registers with their email: https://github.com/dwyl/auth/issues/63